### PR TITLE
Update base image from ubuntu to alpine

### DIFF
--- a/mpi/Dockerfile
+++ b/mpi/Dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/openbce/examples /opt/examples
 RUN cd /opt/examples/mpi && make
 
 # mpi-operator has several dependencies, so alpine does not work for it.
-FROM ubuntu:18.04
+FROM alpine:3.16
 MAINTAINER Klaus Ma <klaus@xflops.cn>
 RUN apk update && apk add openmpi
 COPY --from=build /opt/examples/mpi/allreduce /opt/


### PR DESCRIPTION
ubuntu image does not contain `apk`, we should use alpine as base image.